### PR TITLE
Fixing for terraform v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terraform module to install the CloudWatch agent on EC2 instances using `cloud-i
 
 ---
 
-This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps. 
+This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
 [<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
 [<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
 [<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
@@ -32,7 +32,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
-We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out! 
+We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
 
 
 
@@ -143,7 +143,7 @@ data "aws_iam_policy_document" "ec2_cloudwatch" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["ec2.amazonaws.com"]
     }
@@ -266,9 +266,9 @@ Available targets:
 
 
 
-## Share the Love 
+## Share the Love
 
-Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-cloudwatch-agent)! (it helps us **a lot**) 
+Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-cloudwatch-agent)! (it helps us **a lot**)
 
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
@@ -303,9 +303,9 @@ File a GitHub [issue](https://github.com/cloudposse/terraform-aws-cloudwatch-age
 
 ## Commercial Support
 
-Work directly with our team of DevOps experts via email, slack, and video conferencing. 
+Work directly with our team of DevOps experts via email, slack, and video conferencing.
 
-We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer.
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)][email]
 
@@ -315,7 +315,7 @@ We provide [*commercial support*][commercial_support] for all of our [Open Sourc
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll [develop original modules][module_development] to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures.
 
 
 
@@ -330,7 +330,7 @@ Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Ou
 
 ## Newsletter
 
-Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
+Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
 
 ## Contributing
 
@@ -359,9 +359,9 @@ Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
-## License 
+## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 

--- a/README.yaml
+++ b/README.yaml
@@ -197,7 +197,7 @@ usage: |-
       effect  = "Allow"
       actions = ["sts:AssumeRole"]
 
-      principals = {
+      principals {
         type        = "Service"
         identifiers = ["ec2.amazonaws.com"]
       }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.7.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
   stage      = "${var.stage}"
   name       = "${var.name}"
   namespace  = "${var.namespace}"
@@ -9,7 +9,7 @@ module "label" {
 data "template_file" "cloud_init_cloudwatch_agent" {
   template = "${file("${path.module}/templates/cloud_init.yaml")}"
 
-  vars {
+  vars = {
     cloudwatch_agent_configuration = "${var.metrics_config == "standard" ? base64encode(data.template_file.cloudwatch_agent_configuration_standard.rendered) : base64encode(data.template_file.cloudwatch_agent_configuration_advanced.rendered)}"
   }
 }
@@ -17,7 +17,7 @@ data "template_file" "cloud_init_cloudwatch_agent" {
 data "template_file" "cloudwatch_agent_configuration_advanced" {
   template = "${file("${path.module}/templates/cloudwatch_agent_configuration_advanced.json")}"
 
-  vars {
+  vars = {
     aggregation_dimensions      = "${jsonencode(var.aggregation_dimensions)}"
     cpu_resources               = "${var.cpu_resources}"
     disk_resources              = "${jsonencode(var.disk_resources)}"
@@ -28,7 +28,7 @@ data "template_file" "cloudwatch_agent_configuration_advanced" {
 data "template_file" "cloudwatch_agent_configuration_standard" {
   template = "${file("${path.module}/templates/cloudwatch_agent_configuration_standard.json")}"
 
-  vars {
+  vars = {
     aggregation_dimensions      = "${jsonencode(var.aggregation_dimensions)}"
     cpu_resources               = "${var.cpu_resources}"
     disk_resources              = "${jsonencode(var.disk_resources)}"
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "ec2_cloudwatch" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
 
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["ec2.amazonaws.com"]
     }


### PR DESCRIPTION
This fixes `principals = {` ->  `principals {` and `vars {` to `vars = {` which were identified as error in the  `Terraform v0.12.9` planning step with `provider.aws v2.29.0`

Also updates `terraform-null-label` from `0.7.0` to `0.15.0`